### PR TITLE
fix(encounters): remove key_verse spoilers, fix index version bump

### DIFF
--- a/encounters/ar/zacchaeus_ar_001.json
+++ b/encounters/ar/zacchaeus_ar_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "ar",
   "bible_version": "NAV",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 12,
   "meta": {
     "character": "زَكَّا",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "لوقا 19:10",
-    "text": "فَإِنَّ ابْنَ الإِنْسَانِ قَدْ جَاءَ لِيَبْحَثَ عَنِ الْهَالِكِينَ وَيُخَلِّصَهُمْ.",
+    "reference": "لوقا 19:1-2",
+    "text": "ثُمَّ دَخَلَ أَرِيحَا وَاجْتَازَ فِيهَا. وَإِذَا هُنَاكَ رَجُلٌ اسْمُهُ زَكَّا، رَئِيسٌ لِجُبَاةِ الضَّرَائِبِ، وَكَانَ غَنِيّاً.",
     "bible_version": "NAV"
   },
   "cards": [

--- a/encounters/de/zacchaeus_de_001.json
+++ b/encounters/de/zacchaeus_de_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "de",
   "bible_version": "LU17",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 11,
   "meta": {
     "character": "Zachäus",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "Lukas 19:10",
-    "text": "Denn der Menschensohn ist gekommen, zu suchen und selig zu machen, was verloren ist.",
+    "reference": "Lukas 19:1-2",
+    "text": "Und er ging nach Jericho hinein und zog hindurch. Und siehe, da war ein Mann mit Namen Zachäus, der war ein Oberer der Zöllner und war reich.",
     "bible_version": "LU17"
   },
   "cards": [

--- a/encounters/en/zacchaeus_en_001.json
+++ b/encounters/en/zacchaeus_en_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "en",
   "bible_version": "KJV",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 12,
   "meta": {
     "character": "Zacchaeus",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "Luke 19:10",
-    "text": "For the Son of man is come to seek and to save that which was lost.",
+    "reference": "Luke 19:1-2",
+    "text": "And Jesus entered and passed through Jericho. And, behold, there was a man named Zacchaeus, which was the chief among the publicans, and he was rich.",
     "bible_version": "KJV"
   },
   "cards": [

--- a/encounters/es/zacchaeus_es_001.json
+++ b/encounters/es/zacchaeus_es_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "es",
   "bible_version": "RVR1960",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 12,
   "meta": {
     "character": "Zaqueo",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "Lucas 19:10",
-    "text": "Porque el Hijo del Hombre vino a buscar y a salvar lo que se había perdido.",
+    "reference": "Lucas 19:1-2",
+    "text": "Habiendo entrado Jesús en Jericó, iba pasando por la ciudad. Y sucedió que un varón llamado Zaqueo, que era jefe de los publicanos, y rico,",
     "bible_version": "RVR1960"
   },
   "cards": [

--- a/encounters/fil/zacchaeus_fil_001.json
+++ b/encounters/fil/zacchaeus_fil_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "fil",
   "bible_version": "MBB05",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 15,
   "meta": {
     "character": "Zaqueo",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "Lucas 19:10",
-    "text": "Ang Anak ng Tao ay naparito upang hanapin at iligtas ang naligaw.",
+    "reference": "Lucas 19:1-2",
+    "text": "Pumasok si Jesus sa Jerico at naglakad sa kabayanan. May isang tao roong ang pangalan ay Zaqueo, isang pinuno ng mga maniningil ng buwis at napakayaman.",
     "bible_version": "MBB05"
   },
   "cards": [

--- a/encounters/fr/zacchaeus_fr_001.json
+++ b/encounters/fr/zacchaeus_fr_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "fr",
   "bible_version": "LSG1910",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 14,
   "meta": {
     "character": "Zachée",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "Luc 19:10",
-    "text": "Car le Fils de l'homme est venu chercher et sauver ce qui était perdu.",
+    "reference": "Luc 19:1-2",
+    "text": "Jésus, étant entré dans Jéricho, traversait la ville. Et voici, un homme riche, appelé Zachée, chef des publicains,",
     "bible_version": "LSG1910"
   },
   "cards": [

--- a/encounters/hi/zacchaeus_hi_001.json
+++ b/encounters/hi/zacchaeus_hi_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "hi",
   "bible_version": "HIOV",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 17,
   "meta": {
     "character": "जक्‍कई",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "लूका 19:10",
-    "text": "क्योंकि मनुष्य का पुत्र खोए हुओं को ढूँढ़ने और उनका उद्धार करने आया है।",
+    "reference": "लूका 19:1-2",
+    "text": "वह यरीहो में प्रवेश करके जा रहा था। वहाँ जक्कई नामक एक मनुष्य था जो चुंगी लेनेवालों का सरदार था और धनी था।",
     "bible_version": "HIOV"
   },
   "cards": [

--- a/encounters/index.json
+++ b/encounters/index.json
@@ -2,7 +2,7 @@
   "encounters": [
     {
       "id": "peter_water_001",
-      "version": "2.1",
+      "version": "2.2",
       "image_version": "1.0",
       "emoji": "🌊",
       "status": "published",
@@ -75,7 +75,7 @@
     },
     {
       "id": "bartimaeus_001",
-      "version": "1.6",
+      "version": "1.7",
       "image_version": "1.0",
       "emoji": "👁️",
       "status": "published",
@@ -148,7 +148,7 @@
     },
     {
       "id": "woman_well_001",
-      "version": "1.3",
+      "version": "1.4",
       "image_version": "1.0",
       "emoji": "⛲",
       "status": "published",
@@ -221,7 +221,7 @@
     },
     {
       "id": "zacchaeus_001",
-      "version": "2.3",
+      "version": "2.4",
       "image_version": "1.0",
       "emoji": "🌳",
       "status": "published",

--- a/encounters/ja/zacchaeus_ja_001.json
+++ b/encounters/ja/zacchaeus_ja_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "ja",
   "bible_version": "SK2003",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 15,
   "meta": {
     "character": "ザアカイ",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "ルカ 19:10",
-    "text": "人の子は、失われた人を捜して救うために来たのです。",
+    "reference": "ルカ 19:1-2",
+    "text": "それからイエスは、エリコに入って、町をお通りになった。 ここには、ザアカイという人がいたが、彼は取税人のかしらで、金持ちであった。",
     "bible_version": "SK2003"
   },
   "cards": [

--- a/encounters/pt/zacchaeus_pt_001.json
+++ b/encounters/pt/zacchaeus_pt_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "pt",
   "bible_version": "ARC",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 12,
   "meta": {
     "character": "Zaqueu",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "Lucas 19:10",
-    "text": "Porque o Filho do homem veio buscar e salvar o que se havia perdido.",
+    "reference": "Lucas 19:1-2",
+    "text": "E, tendo Jesus entrado em Jericó, ia passando. E eis que havia ali um homem, chamado Zaqueu; e era este um chefe dos publicanos e era rico.",
     "bible_version": "ARC"
   },
   "cards": [

--- a/encounters/zh/zacchaeus_zh_001.json
+++ b/encounters/zh/zacchaeus_zh_001.json
@@ -4,7 +4,7 @@
   "schema_version": "encounters_v1",
   "language": "zh",
   "bible_version": "CUV1919",
-  "version": "1.0",
+  "version": "1.1",
   "estimated_reading_minutes": 10,
   "meta": {
     "character": "撒该",
@@ -27,8 +27,8 @@
     ]
   },
   "key_verse": {
-    "reference": "路加福音 19:10",
-    "text": "人子来，为要寻找、拯救失丧的人。",
+    "reference": "路加福音 19:1-2",
+    "text": "耶稣进了耶利哥，正经过的时候， 有一个人名叫撒该，作税吏长，是个财主。",
     "bible_version": "CUV1919"
   },
   "cards": [


### PR DESCRIPTION
## Summary
- `key_verse` renders before the first card in the app, so it was previously revealing each encounter's climax/resolution up front (e.g. Bartimeo's healing, Zacchaeus's redemption line, the Samaritan woman's living-water teaching).
- Replaced `key_verse` in `zacchaeus_001` with a non-spoiler opening verse (Luke 19:1-2) across all 10 languages, verified against each language's Bible SOT via the real validator (not by hand).
- Bumped `index.json`'s per-encounter `version` for `zacchaeus_001`, `peter_water_001`, `bartimaeus_001`, and `woman_well_001` — this is the field the app actually reads to detect updated content (not the per-language file's internal `version`), so without this bump the earlier fixes for those three encounters would not have reached devices even though they were already merged to main.

## Test plan
- [x] `validate_family.py zacchaeus_001` — 0 errors/warnings across 10 files
- [x] `validate_encounters.py` (master validator, all phases) — 0 errors/warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)